### PR TITLE
Fix case of WebSocket in examples

### DIFF
--- a/data/kismet/api/device_views.yml
+++ b/data/kismet/api/device_views.yml
@@ -263,7 +263,7 @@
     fetching the key, last-active time, and last signal level.
 
     ```javascript 
-    var ws = new Websocket('ws://host:2501/devices/views/FOOBAR/monitor.ws?'
+    var ws = new WebSocket('ws://host:2501/devices/views/FOOBAR/monitor.ws?'
       'user=username&password=password');
     ws.onmessage = function(msg) {
         var json = JSON.parse(msg.data);

--- a/data/kismet/api/devices.yml
+++ b/data/kismet/api/devices.yml
@@ -441,7 +441,7 @@
     fetching the key, last-active time, and last signal level.
 
     ```javascript 
-    var ws = new Websocket('ws://host:2501/devices/monitor.ws?'
+    var ws = new WebSocket('ws://host:2501/devices/monitor.ws?'
       'user=username&password=password');
     ws.onmessage = function(msg) {
         var json = JSON.parse(msg.data);

--- a/data/kismet/api/eventbus.yml
+++ b/data/kismet/api/eventbus.yml
@@ -271,7 +271,7 @@
     API: 
 
     ```javascript 
-    var ws = new Websocket('ws://host:2501/eventbus/events.ws?'
+    var ws = new WebSocket('ws://host:2501/eventbus/events.ws?'
       'user=username&password=password');
     ws.onmessage = function(msg) {
         var json = JSON.parse(msg.data);


### PR DESCRIPTION
Wrong case causes an error due to JS being case-sensitive.