### PR TITLE
Don't use deprecated apt-key

### DIFF
--- a/layouts/shortcodes/kismet_packages.html
+++ b/layouts/shortcodes/kismet_packages.html
@@ -62,16 +62,16 @@ button {
 </div>
 <div class="flavor-tab-panel" id="tabPanel_1_{{ .key | urlize }}">
 <pre>
-wget -O - https://www.kismetwireless.net/repos/kismet-release.gpg.key | sudo apt-key add -
-echo 'deb https://www.kismetwireless.net/repos/apt/release/{{ .key | lower }} {{ .key | lower }} main' | sudo tee /etc/apt/sources.list.d/kismet.list
+wget -O - https://www.kismetwireless.net/repos/kismet-release.gpg.key|gpg --dearmor | sudo tee /usr/share/keyrings/kismet-archive-keyring.gpg
+echo 'deb [signed-by=/usr/share/keyrings/kismet-archive-keyring.gpg] https://www.kismetwireless.net/repos/apt/release/{{ .key | lower }} {{ .key | lower }} main' | sudo tee /etc/apt/sources.list.d/kismet.list
 sudo apt update
 sudo apt install kismet
 </pre>
 </div>
 <div class="flavor-tab-panel" id="tabPanel_2_{{ .key | urlize }}">
 <pre>
-wget -O - https://www.kismetwireless.net/repos/kismet-release.gpg.key | sudo apt-key add -
-echo 'deb https://www.kismetwireless.net/repos/apt/git/{{ .key | lower }} {{ .key | lower }} main' | sudo tee /etc/apt/sources.list.d/kismet.list
+wget -O - https://www.kismetwireless.net/repos/kismet-release.gpg.key|gpg --dearmor | sudo tee /usr/share/keyrings/kismet-archive-keyring.gpg
+echo 'deb [signed-by=/usr/share/keyrings/kismet-archive-keyring.gpg] https://www.kismetwireless.net/repos/apt/git/{{ .key | lower }} {{ .key | lower }} main' | sudo tee /etc/apt/sources.list.d/kismet.list
 sudo apt update
 sudo apt install kismet
 </pre>


### PR DESCRIPTION
* Notes:
  - Don't use /etc/apt/trusted.gpg.d because the key is always trusted by apt but use [signed-by=] instead
  - I don't know the syntax to add arch=<thearch> before signed-by inside [] but that seems to work without it

Fixes https://github.com/kismetwireless/kismet/issues/434 and https://github.com/kismetwireless/kismet-docs/issues/42

This should be safe to use on older distro. But I am not an expert and I have not tested it nor know where to ask

This comes from https://askubuntu.com/questions/1328806/how-to-solve-apt-key-deprecated as far as I remember