### PR TITLE
Fix link, replacing dash with underscore

### DIFF
--- a/data/kismet/api/devices.yml
+++ b/data/kismet/api/devices.yml
@@ -581,7 +581,7 @@
     This endpoint can run smaller systems out of memory and is generally not
     encouraged.
 
-    A much safer method is to use the [device view API](/docs/api/device-views/)
+    A much safer method is to use the [device view API](/docs/api/device_views/)
     `all` view, using sort-by first seen and a sliding window.
   methods: ["GET", "POST"]
   roles: ["readonly"]


### PR DESCRIPTION
The link had device-views whereas the actual page it meant to link was device_views